### PR TITLE
fix: 修复线程安全和代码质量问题

### DIFF
--- a/src/Vulcan.DapperExtensions/ConnectionManager.cs
+++ b/src/Vulcan.DapperExtensions/ConnectionManager.cs
@@ -31,7 +31,7 @@ namespace Vulcan.DapperExtensions
 
         #region Fields
 
-        private static readonly object LockObject = new object();
+        private readonly object _lockObject = new object();
         private readonly string _dbConnectionString;
 
         private readonly IRuntimeContextStorage _ctxStorage;
@@ -68,12 +68,15 @@ namespace Vulcan.DapperExtensions
 
         internal void AddRef()
         {
-            RefCount += 1;
+            lock (_lockObject)
+            {
+                RefCount += 1;
+            }
         }
 
         private void DeRef()
         {
-            lock (LockObject)
+            lock (_lockObject)
             {
                 RefCount -= 1;
                 if (RefCount != 0) return;

--- a/src/Vulcan.DapperExtensions/ORMapping/BaseEntity.cs
+++ b/src/Vulcan.DapperExtensions/ORMapping/BaseEntity.cs
@@ -12,7 +12,7 @@ namespace Vulcan.DapperExtensions.ORMapping
         private static readonly ConcurrentDictionary<Type, string> _UpdateSqlCache =
             new ConcurrentDictionary<Type, string>();
 
-        private static readonly object _LockObject = new object();
+        private readonly object _LockObject = new object();
         private readonly List<string> _PropertyChangedList = new List<string>();
 
         #region Properties

--- a/src/Vulcan.DapperExtensions/ORMapping/BaseRepository.cs
+++ b/src/Vulcan.DapperExtensions/ORMapping/BaseRepository.cs
@@ -64,7 +64,7 @@ namespace Vulcan.DapperExtensions.ORMapping
                 using (var metrics = CreateSQLMetrics())
                 {
                     var sql = entity.GetInsertSQL(_dbFactory.SQLBuilder);
-                    ret = await mgr.Connection.QueryFirstOrDefaultAsync<long>(entity.GetInsertSQL(_dbFactory.SQLBuilder), entity,
+                    ret = await mgr.Connection.QueryFirstOrDefaultAsync<long>(sql, entity,
                         mgr.Transaction, null, CommandType.Text);
                     metrics.AddToMetrics(sql, entity);
                 }

--- a/src/Vulcan.DapperExtensions/ORMapping/Configuration/EntityConfigurationStore.cs
+++ b/src/Vulcan.DapperExtensions/ORMapping/Configuration/EntityConfigurationStore.cs
@@ -55,6 +55,16 @@ namespace Vulcan.DapperExtensions.ORMapping.Configuration
         }
 
         /// <summary>
+        /// Clears all registered entity configurations.
+        /// This method is primarily intended for unit testing scenarios
+        /// where test isolation is required.
+        /// </summary>
+        internal void Clear()
+        {
+            _cache.Clear();
+        }
+
+        /// <summary>
         /// Converts an EntityTypeBuilder configuration to EntityMeta.
         /// </summary>
         /// <typeparam name="T">The entity type.</typeparam>

--- a/src/Vulcan.DapperExtensions/ORMapping/EntityReflect.cs
+++ b/src/Vulcan.DapperExtensions/ORMapping/EntityReflect.cs
@@ -23,6 +23,16 @@ namespace Vulcan.DapperExtensions.ORMapping
             _configurationStore = store;
         }
 
+        /// <summary>
+        /// Clears the entity metadata cache.
+        /// This method is primarily intended for unit testing scenarios
+        /// where test isolation is required.
+        /// </summary>
+        internal static void ClearCache()
+        {
+            Cache.Clear();
+        }
+
         public static EntityMeta GetDefineInfoFromType(Type type)
         {
             if (Cache.TryGetValue(type, out var entityMeta)) return entityMeta;

--- a/tests/Vulcan.DapperExtensionsUnitTests/Configuration/FluentApiFixture.cs
+++ b/tests/Vulcan.DapperExtensionsUnitTests/Configuration/FluentApiFixture.cs
@@ -1,0 +1,55 @@
+using System;
+using Vulcan.DapperExtensions.ORMapping;
+using Vulcan.DapperExtensions.ORMapping.Configuration;
+using Vulcan.DapperExtensions.ORMapping.MySQL;
+using Xunit;
+
+namespace Vulcan.DapperExtensionsUnitTests.Configuration
+{
+    /// <summary>
+    /// xUnit Collection Fixture for Fluent API tests.
+    /// Ensures tests using EntityReflect share the same configuration store
+    /// and execute serially to avoid static state conflicts.
+    /// </summary>
+    public class FluentApiFixture : IDisposable
+    {
+        public EntityConfigurationStore Store { get; }
+
+        public MySQLSQLBuilder SqlBuilder { get; }
+
+        public FluentApiFixture()
+        {
+            Store = new EntityConfigurationStore();
+            SqlBuilder = MySQLSQLBuilder.Instance;
+
+            // Set the configuration store for EntityReflect
+            // This is shared across all tests in the same collection
+            EntityReflect.SetConfigurationStore(Store);
+        }
+
+        /// <summary>
+        /// Clears both EntityReflect cache and EntityConfigurationStore.
+        /// Call this in test constructor to ensure test isolation.
+        /// </summary>
+        public void ClearAll()
+        {
+            EntityReflect.ClearCache();
+            Store.Clear();
+        }
+
+        public void Dispose()
+        {
+            // Cleanup if needed
+        }
+    }
+
+    /// <summary>
+    /// Collection Definition for Fluent API tests.
+    /// All test classes using this collection will run serially.
+    /// </summary>
+    [CollectionDefinition("FluentApi Collection")]
+    public class FluentApiCollection : ICollectionFixture<FluentApiFixture>
+    {
+        // This class is just a marker, no code needed
+    }
+}

--- a/tests/Vulcan.DapperExtensionsUnitTests/Configuration/FluentApiIntegrationTests.cs
+++ b/tests/Vulcan.DapperExtensionsUnitTests/Configuration/FluentApiIntegrationTests.cs
@@ -246,19 +246,22 @@ namespace Vulcan.DapperExtensionsUnitTests.Configuration
 
     /// <summary>
     /// Integration tests for Fluent API configuration flow and SQL generation.
+    /// Uses FluentApiFixture to ensure tests share the same configuration store
+    /// and run serially to avoid static state conflicts.
     /// </summary>
+    [Collection("FluentApi Collection")]
     public class FluentApiIntegrationTests
     {
         private readonly EntityConfigurationStore _store;
         private readonly MySQLSQLBuilder _sqlBuilder;
 
-        public FluentApiIntegrationTests()
+        public FluentApiIntegrationTests(FluentApiFixture fixture)
         {
-            _store = new EntityConfigurationStore();
-            _sqlBuilder = MySQLSQLBuilder.Instance;
+            _store = fixture.Store;
+            _sqlBuilder = fixture.SqlBuilder;
 
-            // Set the configuration store for EntityReflect
-            EntityReflect.SetConfigurationStore(_store);
+            // Clear both cache and store before each test to ensure isolation
+            fixture.ClearAll();
         }
 
         [Fact]


### PR DESCRIPTION
1. BaseEntity.cs:
   - 将静态锁对象 _LockObject 改为实例成员
   - 避免所有实例共享同一个锁导致的全局锁竞争

2. ConnectionManager.cs:
   - 将静态锁对象 LockObject 改为实例成员 _lockObject
   - 为 AddRef 方法添加锁保护，确保线程安全

3. BaseRepository.cs:
   - 修复 InsertAsync 方法中重复调用 GetInsertSQL 的问题

4. EntityReflect.cs / EntityConfigurationStore.cs:
   - 添加 ClearCache/Clear 方法用于测试隔离

5. 测试改进:
   - 添加 FluentApiFixture 和 CollectionDefinition
   - 确保 Fluent API 测试的隔离性