### PR TITLE
chore: add AI-first project configuration

### DIFF
--- a/.dev/commands.md
+++ b/.dev/commands.md
@@ -1,0 +1,50 @@
+# Standard Commands
+
+> Always use standard CLI commands. Do not use aliases.
+
+## Restore
+```bash
+dotnet restore ./Vulcan.sln
+```
+
+## Build
+```bash
+# Build main library (Release)
+dotnet build ./src/Vulcan.DapperExtensions/Vulcan.DapperExtensions.csproj -c Release
+
+# Build entire solution
+dotnet build ./Vulcan.sln -c Release
+
+# Build with MySQL debug symbols
+dotnet build ./src/Vulcan.DapperExtensions/Vulcan.DapperExtensions.csproj -c MySQLDebug
+```
+
+## Test
+```bash
+# Run all unit tests
+dotnet test ./tests/Vulcan.DapperExtensionsUnitTests/Vulcan.DapperExtensionsUnitTests.csproj
+
+# Run tests with detailed output
+dotnet test ./tests/Vulcan.DapperExtensionsUnitTests/Vulcan.DapperExtensionsUnitTests.csproj --verbosity normal
+
+# Run a single test by fully qualified name
+dotnet test ./tests/Vulcan.DapperExtensionsUnitTests/Vulcan.DapperExtensionsUnitTests.csproj --filter "FullyQualifiedName~Namespace.ClassName.MethodName"
+
+# Run tests matching a pattern
+dotnet test ./tests/Vulcan.DapperExtensionsUnitTests/Vulcan.DapperExtensionsUnitTests.csproj --filter "ClassName~TestClass"
+```
+
+## Pack (NuGet)
+```bash
+dotnet pack ./src/Vulcan.DapperExtensions/Vulcan.DapperExtensions.csproj -c Release -o ./artifacts
+```
+
+## Clean
+```bash
+dotnet clean ./Vulcan.sln
+```
+
+## Format
+```bash
+dotnet format ./Vulcan.sln
+```

--- a/.dev/env.md
+++ b/.dev/env.md
@@ -1,0 +1,18 @@
+# Development Environment
+
+## Runtime
+- .NET SDK: 10.0.201
+- Target Framework: netstandard2.0 (library), net8.0 (tests)
+- Shell: PowerShell (pwsh)
+- Platform: Windows
+
+## Database Support
+- MySQL (MySql.Data 8.0.26)
+- SQL Server (built-in)
+- PostgreSQL (Npgsql extension)
+
+## Notes
+- Prefer standard CLI commands (dotnet / git)
+- Do NOT rely on PowerShell aliases
+- Use cross-platform commands when possible
+- Build configurations: Debug, Release, MySQLDebug

--- a/.dev/tools.md
+++ b/.dev/tools.md
@@ -1,0 +1,17 @@
+# Tools
+
+## Required
+- .NET SDK 10.0+
+- PowerShell (pwsh)
+
+## Recommended
+- Visual Studio 2022 / JetBrains Rider / VS Code
+
+## Optional
+- eza (better ls)
+- zoxide (smart cd)
+- fzf (fuzzy finder)
+
+## Notes
+These tools are optional and should not be required for scripts or CI/CD.
+All build/test commands use standard `dotnet` CLI.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.201",
+    "rollForward": "latestFeature"
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.201",
+    "version": "10.0.102",
     "rollForward": "latestFeature"
   }
 }

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,0 +1,23 @@
+param(
+    [string]$configuration = "Release",
+    [switch]$pack
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Building Vulcan.DapperExtensions ($configuration)..." -ForegroundColor Cyan
+
+dotnet restore ./Vulcan.sln
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+dotnet build ./src/Vulcan.DapperExtensions/Vulcan.DapperExtensions.csproj -c $configuration
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+if ($pack) {
+    Write-Host "Creating NuGet package..." -ForegroundColor Cyan
+    dotnet pack ./src/Vulcan.DapperExtensions/Vulcan.DapperExtensions.csproj -c $configuration -o ./artifacts
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    Write-Host "Package created in ./artifacts" -ForegroundColor Green
+}
+
+Write-Host "Build completed successfully." -ForegroundColor Green

--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -1,0 +1,10 @@
+param(
+    [string]$project = "tests/Vulcan.DapperExtensionsUnitTests"
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Running project: $project" -ForegroundColor Cyan
+
+dotnet run --project $project
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -1,0 +1,24 @@
+param(
+    [string]$filter = "",
+    [string]$verbosity = "normal"
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Running tests..." -ForegroundColor Cyan
+
+$testArgs = @(
+    "test",
+    "./tests/Vulcan.DapperExtensionsUnitTests/Vulcan.DapperExtensionsUnitTests.csproj",
+    "--verbosity", $verbosity
+)
+
+if ($filter) {
+    $testArgs += "--filter"
+    $testArgs += $filter
+}
+
+& dotnet @testArgs
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host "All tests passed." -ForegroundColor Green


### PR DESCRIPTION
- Add .dev/env.md for environment declaration (.NET SDK 10.0, pwsh, Windows)
- Add .dev/commands.md with standard dotnet commands for AI tools
- Add .dev/tools.md with required/optional tool recommendations
- Add global.json to pin .NET SDK version 10.0.201
- Add scripts/build.ps1 with parameterized build script
- Add scripts/test.ps1 with filter and verbosity parameters
- Add scripts/run.ps1 defaulting to test project

This makes the project environment and commands discoverable by AI coding agents (opencode/Claude/Copilot) through standardized declarative files.